### PR TITLE
Move all endpoint to root

### DIFF
--- a/apigee/bikeservice/apiproxy/targets/default.xml
+++ b/apigee/bikeservice/apiproxy/targets/default.xml
@@ -2,7 +2,7 @@
 <TargetEndpoint name="default">
     <DefaultFaultRule name="target-fault">
         <Step>
-            <Name>assignMessage.addCors</Name>
+            <Name>add-cors</Name>
         </Step>
     </DefaultFaultRule>
     <PreFlow name="PreFlow">

--- a/src/org/entur/mobility/bikes/Application.kt
+++ b/src/org/entur/mobility/bikes/Application.kt
@@ -49,7 +49,9 @@ fun Application.module() {
 
     routing {
         get("/") {
-            call.respondText("Hello and welcome to Entur Bikeservice!", ContentType.Application.Json)
+            val host = call.request.host()
+            val port = call.request.port()
+            call.respondText(Gson().toJson(getOperatorsWithDiscovery(host, port)), ContentType.Application.Json)
         }
 
         get("/health") {
@@ -134,11 +136,6 @@ fun Application.module() {
                 }
             }
             call.respondText(Gson().toJson(result), ContentType.Application.Json)
-        }
-        get("/all") {
-            val host = call.request.host()
-            val port = call.request.port()
-            call.respondText(Gson().toJson(getOperatorsWithDiscovery(host, port)), ContentType.Application.Json)
         }
     }
 }


### PR DESCRIPTION
Changed URL to `/mobility/v1/bikes` and return the `all`-response on root