### PR TITLE
Add error handling

### DIFF
--- a/src/org/entur/mobility/bikes/Cache.kt
+++ b/src/org/entur/mobility/bikes/Cache.kt
@@ -1,16 +1,15 @@
 package org.entur.mobility.bikes
 
 import java.time.LocalDateTime
+import java.time.ZoneOffset
 import org.entur.mobility.bikes.bikeOperators.Operator
 
 interface Cache {
     val cacheMap: HashMap<Operator, HashMap<GbfsStandardEnum, GBFSResponse>>
-    val lastUpdated: LocalDateTime
 }
 
 class InMemoryCache(
-    override val cacheMap: HashMap<Operator, HashMap<GbfsStandardEnum, GBFSResponse>>,
-    override var lastUpdated: LocalDateTime
+    override val cacheMap: HashMap<Operator, HashMap<GbfsStandardEnum, GBFSResponse>>
 ) : Cache {
     fun getResponseFromCache(bikeOperator: Operator, gbfsStandardEnum: GbfsStandardEnum): GBFSResponse? {
         return cacheMap[bikeOperator]?.get(gbfsStandardEnum)
@@ -26,11 +25,14 @@ class InMemoryCache(
         } else {
             cacheMap[operator]!![gbfsStandardEnum] = response
         }
-        lastUpdated = LocalDateTime.now()
         return response
     }
 
     fun isValidCache(bikeOperator: Operator, gbfsStandardEnum: GbfsStandardEnum): Boolean =
-        cacheMap[bikeOperator]?.get(gbfsStandardEnum) != null && lastUpdated > LocalDateTime.now()
-            .minusSeconds(TIME_TO_LIVE_CACHE)
+        LocalDateTime.ofEpochSecond(
+            cacheMap[bikeOperator]?.get(gbfsStandardEnum)?.last_updated ?: 0L,
+            0,
+            ZoneOffset.UTC
+        ) > LocalDateTime.now()
+            .minusSeconds(TIME_TO_LIVE_CACHE_SEC)
 }

--- a/src/org/entur/mobility/bikes/constants.kt
+++ b/src/org/entur/mobility/bikes/constants.kt
@@ -1,4 +1,4 @@
 package org.entur.mobility.bikes
 
-const val POLL_INTERVAL = 60000L
-const val TIME_TO_LIVE_CACHE = 60000L
+const val POLL_INTERVAL_MS = 60000L
+const val TIME_TO_LIVE_CACHE_SEC = 60L


### PR DESCRIPTION
Error handling that ensures that data will be served to the client
* The cache mechanism will update the cache for each successful pull. For errors, it will just ignore that iteration and wait for the next cycle.
* If the polling mechanism suddenly stops working, each endpoint will query for data (if the data in the cache is "too old") and then update the cache with fresh data by itself
* If the endpoint tries to fetch data, but fails, it will look for data in the cache even if it is "too old"
* All errors will be logged

The error handling implemented in this PR is probably a little too 'light', and fetch errors should be caught as close to the fetching as possible. However, this works perfectly fine and resolves multiple possible errors due to fetching and casting/mapping of data classes 👍 