### PR TITLE
Change to scheduler and remove suspend

### DIFF
--- a/src/org/entur/mobility/bikes/constants.kt
+++ b/src/org/entur/mobility/bikes/constants.kt
@@ -3,6 +3,7 @@ package org.entur.mobility.bikes
 const val POLL_INTERVAL_MS = 10 * 60000L
 const val TIME_TO_LIVE_CACHE_SEC = 60L
 const val TTL = 15L
+const val TIME_TO_LIVE_DRAMMEN_ACCESS_KEY_MS = 10 * 60000L
 
 val LILLESTROM_API_KEY = System.getenv("LILLESTROM_API_KEY")
 


### PR DESCRIPTION
Changed `while(true)` to `schedule`, and also removed suspend in order to ensure that fetching is done within the same thread.

However, `schedule` does not support variable periods, which means that we cannot set the period time to be dependent on the Drammen-access-token response-TTL. In that case, we could consider reimplementing the `while(true)` logic at that place (which is not a bad solution)