### PR TITLE
Remove setting correlationId in route

### DIFF
--- a/src/org/entur/mobility/bikes/Application.kt
+++ b/src/org/entur/mobility/bikes/Application.kt
@@ -101,9 +101,7 @@ fun Application.module() {
         get("/") {
             val host = call.request.host()
             val port = call.request.port()
-            val correlationId = call.request.headers.get("x-correlation-id")
 
-            if (correlationId != null) call.response.header("x-correlation-id", correlationId)
             call.respondText(Gson().toJson(getOperatorsWithDiscovery(host, port)), ContentType.Application.Json)
         }
 
@@ -116,18 +114,15 @@ fun Application.module() {
         }
 
         get("{operator}/gbfs.json") {
-            val correlationId = call.request.headers.get("x-correlation-id")
             val operator = Operator.valueOf(call.parameters["operator"]?.toUpperCase() ?: throw NullPointerException())
             val gbfsEndpoints = getGbfsEndpoint(operator, call.request.host(), call.request.port())
             val response = getDiscovery(gbfsEndpoints)
 
-            if (correlationId != null) call.response.header("x-correlation-id", correlationId)
             call.respondText(Gson().toJson(response), ContentType.Application.Json)
         }
 
         get("{operator}/{service}.json") {
             val operator = Operator.valueOf(call.parameters["operator"]?.toUpperCase() ?: throw NullPointerException())
-            val correlationId = call.request.headers.get("x-correlation-id")
             val gbfsEnum = GbfsStandardEnum.valueOf(call.parameters["service"] ?: throw NullPointerException())
             if (!cache.isValidCache(operator, gbfsEnum)) {
                 try {
@@ -141,7 +136,6 @@ fun Application.module() {
                 }
             }
             val result = cache.getResponseFromCache(operator, gbfsEnum)
-            if (correlationId != null) call.response.header("x-correlation-id", correlationId)
             call.respondText(Gson().toJson(result), ContentType.Application.Json)
         }
     }


### PR DESCRIPTION
We're already setting it in the interceptor for the call pipeline, so we can remove it in route.