### PR TITLE
Failing gracefully for free_bike_status-requests

### DIFF
--- a/src/org/entur/mobility/bikes/Application.kt
+++ b/src/org/entur/mobility/bikes/Application.kt
@@ -212,6 +212,9 @@ fun fetchAndStoreInCache(
                 )
             }
             GbfsStandardEnum.system_pricing_plans -> urbanSharingSystemPricePlan(operator)
+            GbfsStandardEnum.free_bike_status -> {
+                null
+            }
         }
         if (response != null) cache.setResponseInCacheAndGet(operator, gbfsStandardEnum, response)
     } else if (operator.isKolumbus()) {

--- a/src/org/entur/mobility/bikes/Application.kt
+++ b/src/org/entur/mobility/bikes/Application.kt
@@ -299,6 +299,9 @@ fun fetchAndStoreInCache(
                 ).toStationStatuses()
             }
             GbfsStandardEnum.system_pricing_plans -> drammenSystemPricingPlan()
+            GbfsStandardEnum.free_bike_status -> {
+                null
+            }
         }
         if (response != null) cache.setResponseInCacheAndGet(operator, gbfsStandardEnum, response)
     }

--- a/src/org/entur/mobility/bikes/gbfs.kt
+++ b/src/org/entur/mobility/bikes/gbfs.kt
@@ -12,7 +12,8 @@ enum class GbfsStandardEnum {
     system_information,
     station_information,
     station_status,
-    system_pricing_plans;
+    system_pricing_plans,
+    free_bike_status;
 
     companion object {
         fun GbfsStandardEnum.getFetchUrl(operator: Operator, accessToken: String = ""): String =


### PR DESCRIPTION
Apigee reports ~5k errors per hour on `free_bike_status.json`-requests in dev. The goal of this is to fail gracefully.

